### PR TITLE
add a method to IPAddr instead of breaking a useful one

### DIFF
--- a/lib/fog/ecloud/ipaddr.rb
+++ b/lib/fog/ecloud/ipaddr.rb
@@ -1,5 +1,5 @@
 class IPAddr
-  def mask
+  def mask_string
     _to_string(@mask_addr)
   end
 end

--- a/lib/fog/ecloud/mock_data_classes.rb
+++ b/lib/fog/ecloud/mock_data_classes.rb
@@ -338,7 +338,7 @@ module Fog
         end
 
         def netmask
-          self[:netmask] || subnet_ipaddr.mask
+          self[:netmask] || subnet_ipaddr.mask_string
         end
 
         def dns


### PR DESCRIPTION
When ecloud was extracted, it didn't bring over this patch from base fog:
https://github.com/fog/fog/commit/7a2719fbf9421ee45b88bb65ef9e6718dae2ec4e

https://github.com/fog/fog/pull/907
> @jnewland wrote:
> The monkey patch to IPAddr#mask in the ecloud compute provider unnecessarily removes functionality from IPAddr in both 1.8.7 and 1.9. This pull request adds a method to IPAddr instead of breaking a useful one.
