### PR TITLE
Enhanced API key handling and improved environments collection

### DIFF
--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -289,8 +289,8 @@ module Fog
           @persistent              = options[:persistent] || false
           @version                 = options[:ecloud_version] || "2013-06-01"
           @authentication_method   = options[:ecloud_authentication_method] || :cloud_api_auth
-          @access_key              = options[:ecloud_access_key]
-          @private_key             = options[:ecloud_private_key]
+          @access_key              = options[:ecloud_access_key].to_s
+          @private_key             = options[:ecloud_private_key].to_s
           if @private_key.nil? || @authentication_method == :basic_auth
             @authentication_method = :basic_auth
             @username              = options[:ecloud_username]

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -401,7 +401,7 @@ module Fog
         # section 5.6.3.3 in the ~1000 page pdf spec
         def canonicalize_resource(path)
           uri, query_string = path.split("?")
-          return uri if query_string.nil?
+          return uri.downcase if query_string.nil?
           query_string_pairs = query_string.split("&").sort.map { |e| e.split("=") }
           tm_query_string = query_string_pairs.map { |x| "#{x.first.downcase}:#{x.last}" }.join("\n")
           "#{uri.downcase}\n#{tm_query_string}\n"

--- a/lib/fog/compute/ecloud/models/environments.rb
+++ b/lib/fog/compute/ecloud/models/environments.rb
@@ -12,8 +12,18 @@ module Fog
 
         def all
           data = []
-          service.get_organization(href).body[:Locations][:Location].each do |d|
-            environments = d[:Environments]
+          raw_location = service.get_organization(href).body[:Locations][:Location]
+          if raw_location.is_a?(Array)
+            # If there's more than one location, the XML parser returns an
+            # array.
+            location = raw_location
+          else
+            # Otherwise it returns a hash.
+            location = [raw_location]
+          end
+
+          location.each do |l|
+            environments = l[:Environments]
             next unless environments
             if environments[:Environment].is_a?(Array)
               environments[:Environment].each { |e| data << e }


### PR DESCRIPTION
I've put in an explicit to_s call for the API key data so that we can use the live spec mode for testing.

The second commit fixes the environments collection's handling of single location responses.

The third one fixes canonicalizing resources when there is no query string. It wasn't returning a downcased version of the string in that case.