### PR TITLE
Added reload method to ensure that reloads work as expected.

### DIFF
--- a/lib/fog/compute/ecloud/models/organization.rb
+++ b/lib/fog/compute/ecloud/models/organization.rb
@@ -39,6 +39,19 @@ module Fog
           end
         end
 
+        # Set instance variables for child collections/models to nil so that they will be reloaded correctly
+        #
+        # @return nothing
+        def reload
+          @locations = nil
+          @environments = nil
+          @tags = nil
+          @admin = nil
+          @users = nil
+          @support_tickets = nil
+          super
+        end
+
         def edit_authentication_levels(options = {})
           options[:uri] = "#{service.base_path}/admin/organizations/#{id}/authenticationLevels"
           data = service.admin_edit_authentication_levels(options).body


### PR DESCRIPTION
I've added class specific reload that sets all instance variables to nil when a reload is called. This ensures that the ||= assignments will load new data after a reload instead of returning the same stale data. It should be put in all models/collections that use ||=, but I'm not at that point in my code review yet. I was planning on adding them as I work through the classes, but can do it in one big commit if you'd like.