### PR TITLE
Ensure that Content-Length is added to POSTs with bodies

### DIFF
--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -356,8 +356,8 @@ module Fog
             "x-tmrk-version" => @version,
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
-          if params[:body].size > 0 || (params[:method] == 'POST' || params[:method] == 'PUT')
-            params[:headers].merge!('Content-Length' => params[:body].size) unless params[:headers]['Content-Length']
+          if params[:body].size > 0 || (params[:method] == "POST" || params[:method] == "PUT")
+            params[:headers].merge!("Content-Length" => params[:body].size) unless params[:headers]["Content-Length"]
           end
           if params[:method] == "POST" || params[:method] == "PUT"
             params[:headers].merge!("Content-Type" => "application/xml") unless params[:headers]["Content-Type"]

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -356,10 +356,14 @@ module Fog
             "x-tmrk-version" => @version,
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
-          if params[:body].size > 0 || (params[:method] == "POST" || params[:method] == "PUT")
-            params[:headers].merge!("Content-Length" => params[:body].size) unless params[:headers]["Content-Length"]
-          end
-          if params[:method] == "POST" || params[:method] == "PUT"
+          if params[:method] == "POST" || params[:method] == "PUT" || params[:method] == "DELETE"
+            if !params[:headers]['Content-Length']
+              body_size = 0
+              if params[:body]
+                body_size = params[:body].size
+              end
+              params[:headers].merge!("Content-Length" => body_size)
+            end
             params[:headers].merge!("Content-Type" => "application/xml") unless params[:headers]["Content-Type"]
             params[:headers].merge!("Accept" => "application/xml")
           end

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -352,18 +352,19 @@ module Fog
 
         # if Authorization and x-tmrk-authorization are used, the x-tmrk-authorization takes precendence.
         def set_extra_headers_for(params)
+          length_required = ["PUT", "POST", "DELETE"]
           params[:headers] = {
             "x-tmrk-version" => @version,
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
-          if params[:method] == "POST" || params[:method] == "PUT" || params[:method] == "DELETE"
-            if !params[:headers]["Content-Length"]
-              body_size = 0
-              if params[:body]
-                body_size = params[:body].size
-              end
-              params[:headers].merge!("Content-Length" => body_size)
+          if length_required.include?(params[:method]) && !params[:headers]["Content-Length"]
+            body_size = 0
+            if params[:body]
+              body_size = params[:body].size
             end
+            params[:headers].merge!("Content-Length" => body_size)
+          end
+          if params[:method] == "POST" || params[:method] == "PUT"
             params[:headers].merge!("Content-Type" => "application/xml") unless params[:headers]["Content-Type"]
             params[:headers].merge!("Accept" => "application/xml")
           end

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -357,7 +357,7 @@ module Fog
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
           if params[:method] == "POST" && params[:body].size > 0
-            params[:headers].merge!("Content-Length" => params[:body].size) unless params[:headers]['Content-Length']
+            params[:headers].merge!("Content-Length" => params[:body].size) unless params[:headers]["Content-Length"]
           end
           if params[:method] == "POST" || params[:method] == "PUT"
             params[:headers].merge!("Content-Type" => "application/xml") unless params[:headers]["Content-Type"]

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -356,6 +356,9 @@ module Fog
             "x-tmrk-version" => @version,
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
+          if params[:method] == "POST" && params[:body].size > 0
+            params[:headers].merge!("Content-Length" => params[:body].size) unless params[:headers]['Content-Length']
+          end
           if params[:method] == "POST" || params[:method] == "PUT"
             params[:headers].merge!("Content-Type" => "application/xml") unless params[:headers]["Content-Type"]
             params[:headers].merge!("Accept" => "application/xml")

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -357,7 +357,7 @@ module Fog
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
           if params[:method] == "POST" || params[:method] == "PUT" || params[:method] == "DELETE"
-            if !params[:headers]['Content-Length']
+            if !params[:headers]["Content-Length"]
               body_size = 0
               if params[:body]
                 body_size = params[:body].size

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -356,8 +356,8 @@ module Fog
             "x-tmrk-version" => @version,
             "Date"           => Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT"),
           }.merge(params[:headers] || {})
-          if params[:method] == "POST" && params[:body].size > 0
-            params[:headers].merge!("Content-Length" => params[:body].size) unless params[:headers]["Content-Length"]
+          if params[:body].size > 0 || (params[:method] == 'POST' || params[:method] == 'PUT')
+            params[:headers].merge!('Content-Length' => params[:body].size) unless params[:headers]['Content-Length']
           end
           if params[:method] == "POST" || params[:method] == "PUT"
             params[:headers].merge!("Content-Type" => "application/xml") unless params[:headers]["Content-Type"]


### PR DESCRIPTION
The current API throws InvalidSignature errors because the Content-Length header was missing. This makes sure it's added to the headers before the signature is generated and POSTs with non-zero length bodies are now succeeding.