### PR TITLE
Added support for creating, editing, and deleting ssh keys

### DIFF
--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -229,6 +229,7 @@ module Fog
       request :rows_edit
       request :rows_movedown
       request :rows_moveup
+      request :ssh_key_create
       request :trusted_network_groups_create
       request :trusted_network_groups_delete
       request :trusted_network_groups_edit

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -231,6 +231,7 @@ module Fog
       request :rows_moveup
       request :ssh_key_create
       request :ssh_key_delete
+      request :ssh_key_edit
       request :trusted_network_groups_create
       request :trusted_network_groups_delete
       request :trusted_network_groups_edit

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -230,6 +230,7 @@ module Fog
       request :rows_movedown
       request :rows_moveup
       request :ssh_key_create
+      request :ssh_key_delete
       request :trusted_network_groups_create
       request :trusted_network_groups_delete
       request :trusted_network_groups_edit

--- a/lib/fog/compute/ecloud/models/ssh_key.rb
+++ b/lib/fog/compute/ecloud/models/ssh_key.rb
@@ -16,6 +16,24 @@ module Fog
         end
         alias_method :destroy, :delete
 
+        def edit(options = {})
+          # Make sure we only pass what we should
+          new_options = {}
+          new_options[:uri] = href
+          if options[:name].nil?
+            new_options[:name] = name
+          else
+            new_options[:name] = options[:name]
+          end
+          if options[:default].nil?
+            new_options[:default] = default
+          else
+            new_options[:default] = options[:default]
+          end
+
+          service.ssh_key_edit(new_options).body
+        end
+
         def id
           href.scan(/\d+/)[0]
         end

--- a/lib/fog/compute/ecloud/models/ssh_key.rb
+++ b/lib/fog/compute/ecloud/models/ssh_key.rb
@@ -12,8 +12,7 @@ module Fog
         attribute :private_key, :aliases => :PrivateKey
 
         def delete
-          data = service.ssh_key_delete(href).body
-          self.service.tasks.new(data)
+          service.ssh_key_delete(href).body
         end
         alias_method :destroy, :delete
 

--- a/lib/fog/compute/ecloud/models/ssh_key.rb
+++ b/lib/fog/compute/ecloud/models/ssh_key.rb
@@ -11,6 +11,12 @@ module Fog
         attribute :finger_print, :aliases => :FingerPrint
         attribute :private_key, :aliases => :PrivateKey
 
+        def delete
+          data = service.ssh_key_delete(href).body
+          self.service.tasks.new(data)
+        end
+        alias_method :destroy, :delete
+
         def id
           href.scan(/\d+/)[0]
         end

--- a/lib/fog/compute/ecloud/models/ssh_key.rb
+++ b/lib/fog/compute/ecloud/models/ssh_key.rb
@@ -9,6 +9,7 @@ module Fog
         attribute :other_links, :aliases => :Links
         attribute :default, :aliases => :Default, :type => :boolean
         attribute :finger_print, :aliases => :FingerPrint
+        attribute :private_key, :aliases => :PrivateKey
 
         def id
           href.scan(/\d+/)[0]

--- a/lib/fog/compute/ecloud/models/ssh_key.rb
+++ b/lib/fog/compute/ecloud/models/ssh_key.rb
@@ -20,18 +20,18 @@ module Fog
           # Make sure we only pass what we should
           new_options = {}
           new_options[:uri] = href
-          if options[:name].nil?
-            new_options[:name] = name
+          if options[:Name].nil?
+            new_options[:Name] = name
           else
-            new_options[:name] = options[:name]
+            new_options[:Name] = options[:Name]
           end
-          if options[:default].nil?
-            new_options[:default] = default
+          if options[:Default].nil?
+            new_options[:Default] = default
           else
-            new_options[:default] = options[:default]
+            new_options[:Default] = options[:Default]
           end
 
-          service.ssh_key_edit(new_options).body
+          service.ssh_key_edit(new_options)
         end
 
         def id

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -29,7 +29,7 @@ module Fog
           new_options[:uri]     = href + "/action/createSshKey"
 
           data = service.ssh_key_create(new_options).body
-          object = self.service.ssh_keys.new(data)
+          object = service.ssh_keys.new(data)
           object
         end
 

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -24,7 +24,7 @@ module Fog
         def create(options = {})
           # Make sure we only pass what we should
           new_options           = {}
-          new_options[:name]    = options[:name]
+          new_options[:name]    = options[:name] unless options[:name].nil?
           new_options[:default] = options[:default] || false
           new_options[:uri]     = href + "/action/createSshKey"
 

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -28,7 +28,7 @@ module Fog
           new_options[:default] = options[:default] || false
           new_options[:uri]     = href + "/action/createSshKey"
 
-          data = service.ssh_key_create(new_options).body
+          data = service.ssh_key_create(new_options)
           object = service.ssh_keys.new(data)
           object
         end

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -17,7 +17,7 @@ module Fog
           if data = service.get_ssh_key(uri).body
             new(data)
           end
-        rescue Fog::Errors::NotFound
+        rescue Excon::Errors::NotFound
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -24,8 +24,8 @@ module Fog
         def create(options = {})
           # Make sure we only pass what we should
           new_options           = {}
-          new_options[:name]    = options[:name] unless options[:name].nil?
-          new_options[:default] = options[:default] || false
+          new_options[:Name]    = options[:Name] unless options[:Name].nil?
+          new_options[:Default] = options[:Default] || false
           new_options[:uri]     = href + "/action/createSshKey"
 
           data = service.ssh_key_create(new_options)

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -20,6 +20,22 @@ module Fog
         rescue Fog::Errors::NotFound
           nil
         end
+
+        def create(options = {})
+          # Make sure we only pass what we should
+          new_options           = {}
+          new_options[:name]    = options[:name]
+          new_options[:default] = options[:default] || false
+          new_options[:uri]     = href + "/action/createSshKey"
+
+          data = service.ssh_key_create(new_options).body
+          object = self.service.ssh_keys.new(data)
+          object
+        end
+
+        def environment_id
+          href.scan(/\d+/)[0]
+        end
       end
     end
   end

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -14,8 +14,8 @@ module Fog
         end
 
         def get(uri)
-          if data = service.get_ssh_key(uri)
-            new(data.body)
+          if data = service.get_ssh_key(uri).body
+            new(data)
           end
         rescue Fog::Errors::NotFound
           nil

--- a/lib/fog/compute/ecloud/requests/get_ssh_key.rb
+++ b/lib/fog/compute/ecloud/requests/get_ssh_key.rb
@@ -12,7 +12,7 @@ module Fog
 
           if ssh_key
             response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization))
-          else response(:status => 404) # ?
+          else response(:expects => 200, :status => 404) # ?
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -26,6 +26,51 @@ module Fog
           end
         end
       end
+
+      class Mock
+        include Shared
+
+        def ssh_key_create(data)
+          ssh_key_id          = Fog::Mock.random_numbers(7).to_i
+          ssh_key_fingerprint = ""
+          for x in 1..15
+            ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2) + ':'
+          end
+          ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2)
+          ssh_private_key     = Fog::Mock.random_base64(512)
+          org_id              = self.data[:organization_id]
+          org_name            = self.data[:organization_name]
+
+          ssh_key = {
+            :href                  => "/cloudapi/ecloud/admin/sshKeys/#{ssh_key_id}",
+            :name                  => data[:name],
+            :type                  => "application/vnd.tmrk.cloud.admin.sshKey",
+            :Links => {
+              :Link => {
+                :href => "/cloudapi/ecloud/admin/organizations/#{org_id}",
+                :name => org_name,
+                :type => "application/vnd.tmrk.cloud.admin.organization",
+                :rel  => "up",
+              },
+              :Link => {
+                :href => "/cloudapi/ecloud/organizations/#{org_id}",
+                :name => org_name,
+                :type => "application/vnd.tmrk.cloud.organization",
+                :rel  => "up",
+              },
+            },
+            :Default => data[:default] || false,
+            :FingerPrint => ssh_key_fingerprint,
+            :PrivateKey => ssh_private_key,
+          }
+
+          ssh_key_response = response(:body =>  ssh_key)
+
+          self.data[:ssh_keys][ssh_key_id] = ssh_key
+
+          ssh_key_response
+        end
+      end
     end
   end
 end

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class Ecloud
+      class Real
+        include Shared
+
+        def ssh_key_create(data)
+          validate_data([:name], data)
+
+          request(
+            :body => generate_ssh_key_create_request(data),
+            :expects => 201,
+            :method => "POST",
+            :headers => {},
+            :uri => data[:uri],
+            :parse => true
+          )
+        end
+
+        private
+
+        def generate_ssh_key_create_request(data)
+          xml = Builder::XmlMarkup.new
+          xml.CreateSshKey(:name => data[:name]) do
+            xml.Default data[:default]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -33,7 +33,7 @@ module Fog
         def ssh_key_create(data)
           ssh_key_id          = Fog::Mock.random_numbers(7).to_i
           ssh_key_fingerprint = ""
-          for x in 1..15
+          (1..15).each do
             ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2) + ":"
           end
           ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2)

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -31,6 +31,7 @@ module Fog
         include Shared
 
         def ssh_key_create(data)
+          validate_data([:name], data)
           ssh_key_id          = Fog::Mock.random_numbers(7).to_i
           ssh_key_fingerprint = ""
           (1..15).each do

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -34,7 +34,7 @@ module Fog
           ssh_key_id          = Fog::Mock.random_numbers(7).to_i
           ssh_key_fingerprint = ""
           for x in 1..15
-            ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2) + ':'
+            ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2) + ":"
           end
           ssh_key_fingerprint = ssh_key_fingerprint + Fog::Mock.random_hex(2)
           ssh_private_key     = Fog::Mock.random_base64(512)

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -14,7 +14,7 @@ module Fog
             :headers => {},
             :uri => data[:uri],
             :parse => true
-          )
+          ).body
         end
 
         private
@@ -68,7 +68,7 @@ module Fog
 
           self.data[:ssh_keys][ssh_key_id] = ssh_key
 
-          ssh_key_response
+          ssh_key_response.body
         end
       end
     end

--- a/lib/fog/compute/ecloud/requests/ssh_key_create.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_create.rb
@@ -5,7 +5,7 @@ module Fog
         include Shared
 
         def ssh_key_create(data)
-          validate_data([:name], data)
+          validate_data([:Name], data)
 
           request(
             :body => generate_ssh_key_create_request(data),
@@ -21,8 +21,8 @@ module Fog
 
         def generate_ssh_key_create_request(data)
           xml = Builder::XmlMarkup.new
-          xml.CreateSshKey(:name => data[:name]) do
-            xml.Default data[:default]
+          xml.CreateSshKey(:name => data[:Name]) do
+            xml.Default data[:Default]
           end
         end
       end
@@ -31,7 +31,7 @@ module Fog
         include Shared
 
         def ssh_key_create(data)
-          validate_data([:name], data)
+          validate_data([:Name], data)
           ssh_key_id          = Fog::Mock.random_numbers(7).to_i
           ssh_key_fingerprint = ""
           (1..15).each do
@@ -44,7 +44,7 @@ module Fog
 
           ssh_key = {
             :href                  => "/cloudapi/ecloud/admin/sshKeys/#{ssh_key_id}",
-            :name                  => data[:name],
+            :Name                  => data[:Name],
             :type                  => "application/vnd.tmrk.cloud.admin.sshKey",
             :Links => {
               :Link => {
@@ -60,7 +60,7 @@ module Fog
                 :rel  => "up",
               },
             },
-            :Default => data[:default] || false,
+            :Default => data[:Default] || false,
             :FingerPrint => ssh_key_fingerprint,
             :PrivateKey => ssh_private_key,
           }

--- a/lib/fog/compute/ecloud/requests/ssh_key_delete.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_delete.rb
@@ -9,7 +9,7 @@ module Fog
         def ssh_key_delete(uri)
           ssh_key_id = id_from_uri(uri)
 
-          self.data[:ssh_keys].delete(ssh_key_id)
+          data[:ssh_keys].delete(ssh_key_id)
           response(:body =>  nil, :status => 204)
         end
       end

--- a/lib/fog/compute/ecloud/requests/ssh_key_delete.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_delete.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Ecloud
+      class Real
+        basic_request :ssh_key_delete, 204, "DELETE"
+      end
+
+      class Mock
+        def ssh_key_delete(uri)
+          ssh_key_id = id_from_uri(uri)
+
+          ssh_key = self.data[:ssh_keys][ssh_key_id]
+          self.data[:ssh_keys].delete(ssh_key_id)
+          response(:body =>  nil, :status => 204)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/ecloud/requests/ssh_key_delete.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_delete.rb
@@ -9,7 +9,6 @@ module Fog
         def ssh_key_delete(uri)
           ssh_key_id = id_from_uri(uri)
 
-          ssh_key = self.data[:ssh_keys][ssh_key_id]
           self.data[:ssh_keys].delete(ssh_key_id)
           response(:body =>  nil, :status => 204)
         end

--- a/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
@@ -7,7 +7,7 @@ module Fog
         def ssh_key_edit(data)
           request(
             :body => generate_ssh_key_edit_request(data),
-            :expects => [202, 204],
+            :expects => 200,
             :method => "PUT",
             :headers => {},
             :uri => data[:uri],

--- a/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
@@ -24,6 +24,20 @@ module Fog
           end
         end
       end
+
+      class Mock
+        def ssh_key_edit(data)
+          ssh_key_id = id_from_uri(data[:uri]).to_i
+          if self.data[:ssh_keys][ssh_key_id]
+            self.data[:ssh_keys][ssh_key_id][:name] = data[:name]
+            self.data[:ssh_keys][ssh_key_id][:default] = data[:default]
+            ssh_key = self.data[:ssh_keys][ssh_key_id]
+            response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization))
+          else
+            response(:status => 404)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
@@ -28,10 +28,10 @@ module Fog
       class Mock
         def ssh_key_edit(options)
           ssh_key_id = id_from_uri(options[:uri]).to_i
-          if self.data[:ssh_keys][ssh_key_id]
-            self.data[:ssh_keys][ssh_key_id][:Name] = options[:Name]
-            self.data[:ssh_keys][ssh_key_id][:Default] = options[:Default]
-            ssh_key = self.data[:ssh_keys][ssh_key_id]
+          if data[:ssh_keys][ssh_key_id]
+            data[:ssh_keys][ssh_key_id][:Name] = options[:Name]
+            data[:ssh_keys][ssh_key_id][:Default] = options[:Default]
+            ssh_key = data[:ssh_keys][ssh_key_id]
             response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization)).body
           else
             response(:expects => 200, :status => 404)

--- a/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
@@ -1,0 +1,29 @@
+module Fog
+  module Compute
+    class Ecloud
+      class Real
+        include Shared
+
+        def ssh_key_edit(data)
+          request(
+            :body => generate_ssh_key_edit_request(data),
+            :expects => [202, 204],
+            :method => "PUT",
+            :headers => {},
+            :uri => data[:uri],
+            :parse => true
+          )
+        end
+
+        private
+
+        def generate_ssh_key_edit_request(data)
+          xml = Builder::XmlMarkup.new
+          xml.SshKey(:name => data[:name]) do
+            xml.Default data[:default]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
@@ -12,29 +12,29 @@ module Fog
             :headers => {},
             :uri => data[:uri],
             :parse => true
-          )
+          ).body
         end
 
         private
 
         def generate_ssh_key_edit_request(data)
           xml = Builder::XmlMarkup.new
-          xml.SshKey(:name => data[:name]) do
-            xml.Default data[:default]
+          xml.SshKey(:name => data[:Name]) do
+            xml.Default data[:Default]
           end
         end
       end
 
       class Mock
-        def ssh_key_edit(data)
-          ssh_key_id = id_from_uri(data[:uri]).to_i
+        def ssh_key_edit(options)
+          ssh_key_id = id_from_uri(options[:uri]).to_i
           if self.data[:ssh_keys][ssh_key_id]
-            self.data[:ssh_keys][ssh_key_id][:name] = data[:name]
-            self.data[:ssh_keys][ssh_key_id][:default] = data[:default]
+            self.data[:ssh_keys][ssh_key_id][:Name] = options[:Name]
+            self.data[:ssh_keys][ssh_key_id][:Default] = options[:Default]
             ssh_key = self.data[:ssh_keys][ssh_key_id]
-            response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization))
+            response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization)).body
           else
-            response(:status => 404)
+            response(:expects => 200, :status => 404)
           end
         end
       end

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -18,7 +18,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   end
 
   tests("#create").succeeds do
-    new_key = @ssh_keys.create({:name => "testing"})
+    new_key = @ssh_keys.create(:name => "testing")
     @key_id = new_key.id || nil
     returns(false) { new_key.nil? }
   end
@@ -26,7 +26,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   tests("#edit").succeeds do
     the_key = @ssh_keys.get(@key_id)
     returns(false) { the_key.nil? }
-    the_key.edit({:name => "more testing"})
+    the_key.edit(:name => "more testing")
     the_key.reload
     returns(false) { the_key.name != "more testing" }
   end

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -22,7 +22,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
     new_key = @ssh_keys.create(:name => "testing")
     @key_id = new_key.id || nil
     returns(false) { new_key.nil? }
-    raises(ArgumentError) { @ssh_keys.create() }
+    raises(ArgumentError) { @ssh_keys.create }
   end
 
   tests("#edit").succeeds do

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -16,4 +16,26 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
 
     returns(false) { @ssh_keys.get(ssh_key.href).nil? }
   end
+
+  tests('#create').succeeds do
+    new_key = @ssh_keys.create(name: "testing")
+    @key_id = new_key.id || nil
+    returns(false) { new_key.nil? }
+  end
+
+  tests('#edit').succeeds do
+    the_key = @ssh_keys.get(@key_id)
+    returns(false) { the_key.nil? }
+    the_key.edit(name: "more testing")
+    the_key.reload
+    returns(false) { the_key.name != "more testing" }
+  end
+
+  tests('#delete').succeeds do
+    the_key = @ssh_keys.get(@key_id)
+    returns(false) { the_key.nil? }
+    the_key.delete
+    the_key = @ssh_keys.get(@key_id)
+    returns(false) { !the_key.nil? }
+  end
 end

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -7,31 +7,31 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   @admin_organization.reload
   @ssh_keys = @admin_organization.ssh_keys
 
-  tests('#all').succeeds do
+  tests("#all").succeeds do
     returns(false) { @ssh_keys.empty? }
   end
 
-  tests('#get').succeeds do
+  tests("#get").succeeds do
     ssh_key = @ssh_keys.first
 
     returns(false) { @ssh_keys.get(ssh_key.href).nil? }
   end
 
-  tests('#create').succeeds do
-    new_key = @ssh_keys.create(name: "testing")
+  tests("#create").succeeds do
+    new_key = @ssh_keys.create({:name => "testing"})
     @key_id = new_key.id || nil
     returns(false) { new_key.nil? }
   end
 
-  tests('#edit').succeeds do
+  tests("#edit").succeeds do
     the_key = @ssh_keys.get(@key_id)
     returns(false) { the_key.nil? }
-    the_key.edit(name: "more testing")
+    the_key.edit({:name => "more testing"})
     the_key.reload
     returns(false) { the_key.name != "more testing" }
   end
 
-  tests('#delete').succeeds do
+  tests("#delete").succeeds do
     the_key = @ssh_keys.get(@key_id)
     returns(false) { the_key.nil? }
     the_key.delete

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -15,12 +15,14 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
     ssh_key = @ssh_keys.first
 
     returns(false) { @ssh_keys.get(ssh_key.href).nil? }
+    returns(false) { @ssh_keys.get("/notfound" + ssh_key.href).nil? }
   end
 
   tests("#create").succeeds do
     new_key = @ssh_keys.create(:name => "testing")
     @key_id = new_key.id || nil
     returns(false) { new_key.nil? }
+    raises(ArgumentError) { @ssh_keys.create() }
   end
 
   tests("#edit").succeeds do
@@ -29,6 +31,9 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
     the_key.edit(:name => "more testing")
     the_key.reload
     returns(false) { the_key.name != "more testing" }
+    the_key.edit(:default => true)
+    the_key.reload
+    returns(true) { the_key.default }
   end
 
   tests("#delete").succeeds do

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -19,7 +19,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   end
 
   tests("#create").succeeds do
-    new_key = @ssh_keys.create(:name => "testing")
+    new_key = @ssh_keys.create(:Name => "testing")
     @key_id = new_key.id || nil
     returns(false) { new_key.nil? }
     raises(ArgumentError) { @ssh_keys.create }
@@ -28,10 +28,12 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   tests("#edit").succeeds do
     the_key = @ssh_keys.get(@key_id)
     returns(false) { the_key.nil? }
-    the_key.edit(:name => "more testing")
+
+    the_key.edit(:Name => "more testing")
     the_key.reload
     returns(false) { the_key.name != "more testing" }
-    the_key.edit(:default => true)
+
+    the_key.edit(:Default => true)
     the_key.reload
     returns(true) { the_key.default }
   end


### PR DESCRIPTION
I've added support for creating, editing, and deleting ssh keys. I've also added the mock support and created new tests for this functionality. Everything's passing my tests, both in the mock data as well as using the spec interface and real keys in my cloud environment.