### PR TITLE
Version 0.1.4

### DIFF
--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -287,7 +287,7 @@ module Fog
           @connection_options      = options[:connection_options] || {}
           @host                    = options[:ecloud_host] || API_URL
           @persistent              = options[:persistent] || false
-          @version                 = options[:ecloud_version] || "2013-06-01"
+          @version                 = options[:ecloud_version] || "2015-05-01"
           @authentication_method   = options[:ecloud_authentication_method] || :cloud_api_auth
           @access_key              = options[:ecloud_access_key]
           @private_key             = options[:ecloud_private_key]

--- a/lib/fog/ecloud/version.rb
+++ b/lib/fog/ecloud/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Ecloud
-    VERSION = "0.1.4"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/fog/ecloud/version.rb
+++ b/lib/fog/ecloud/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Ecloud
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
I think it's time for a new release so that we can get the ssh key management functionality out there. I've replaced the API version with the current one and bumped the gem version.