### PR TITLE
Excon exception handling

### DIFF
--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -271,7 +271,7 @@ module Fog
         include Shared
         include Errors
 
-        class Fog::Compute::Ecloud::ServiceError < Fog::Ecloud::Errors::ServiceError ; end
+        class Fog::Compute::Ecloud::ServiceError < Fog::Ecloud::Errors::ServiceError; end
 
         class << self
           def basic_request(name, expects = [200], method = :get, headers = {}, body = "")
@@ -438,7 +438,7 @@ module Fog
         include Shared
         include Errors
 
-        class Fog::Compute::Ecloud::ServiceError < Fog::Ecloud::Errors::ServiceError ; end
+        class Fog::Compute::Ecloud::ServiceError < Fog::Ecloud::Errors::ServiceError; end
 
         def self.data
           @data ||= Hash.new do |hash, key|

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -266,8 +266,97 @@ module Fog
         end
       end
 
+      # Custom errors specific to our implementation
+      module Errors
+        # The parent class for all errors in the Fog::Compute::Ecloud module.
+        class Fog::Compute::Ecloud::ServiceError < Fog::Errors::Error
+          # @!attribute [r] response_data
+          #   @return [string] the response from the HTTP request
+
+          # @!attribute [r] status_code
+          #   @return [Integer] the HTTP status code returned
+          attr_reader :response_data, :status_code, :minor_error_code
+
+          # Make the HTTP status code pretty
+          #
+          # @return [String] the cleaned up status code
+          def to_s
+            status = status_code ? "HTTP #{status_code}" : "HTTP <Unknown>"
+            minor_code = minor_error_code ? minor_error_code : "Unknown"
+            "[#{status} - #{minor_code}] #{super}"
+          end
+
+          # Parse the response from the HTTP request to create a user friendly
+          #   message, including HTTP response code and error message (if any)
+          #
+          # @param [Object] error the error object from the rescue block
+          #
+          # @return [Object] the new error object
+          def self.slurp(error)
+            data = nil
+            message = nil
+            status_code = nil
+            minor_code = nil
+
+            if error.response
+              status_code = error.response.status
+              unless error.response.body.empty?
+                begin
+                  document = Fog::ToHashDocument.new
+                  parser = Nokogiri::XML::SAX::PushParser.new(document)
+                  parser << error.response.body
+                  parser.finish
+
+                  data = document.body
+
+                  message = extract_message(data)
+                  minor_code = extract_minor_code(data)
+
+                rescue => e
+                  Fog::Logger.warning("Received exception '#{e}' while decoding: #{error.response.body}")
+                  message = error.response.body
+                  data = error.response.body
+                end
+              end
+            end
+
+            new_error = super(error, message)
+            new_error.instance_variable_set(:@response_data, data)
+            new_error.instance_variable_set(:@status_code, status_code)
+            new_error.instance_variable_set(:@minor_error_code, minor_code)
+            new_error
+          end
+
+          # Parse the response body for an error message
+          #
+          # @param [Hash] data the decoded XML response
+          #
+          # @return [String] the error message, if found, otherwise the raw data
+          def self.extract_message(data)
+            if data.is_a?(Hash)
+              message = data[:message]
+            end
+            message || data.inspect
+          end
+
+          # Parse the response body for the minor error code
+          #
+          # @param [Hash] data the decoded XML response
+          #
+          # @return [String] the error minor error code, if found, otherwise nil
+          def self.extract_minor_code(data)
+            minor_code = nil
+            if data.is_a?(Hash)
+              minor_code = data[:minorErrorCode]
+            end
+            minor_code
+          end
+        end
+      end
+
       class Real
         include Shared
+        include Errors
 
         class << self
           def basic_request(name, expects = [200], method = :get, headers = {}, body = "")
@@ -335,7 +424,13 @@ module Fog
           unless params[:body].nil? || params[:body].empty?
             options.merge!(:body => params[:body])
           end
-          response = @connections[host_url].request(options)
+
+          begin
+            response = @connections[host_url].request(options)
+          rescue Excon::Errors::Error => error
+            raise ServiceError.slurp(error)
+          end
+
           # Parse the response body into a hash
           unless response.body.empty?
             if params[:parse]
@@ -426,6 +521,7 @@ module Fog
 
       class Mock
         include Shared
+        include Errors
 
         def self.data
           @data ||= Hash.new do |hash, key|
@@ -828,7 +924,9 @@ module Fog
 
           response = Excon::Response.new(:body => body, :headers => headers, :status => status)
           if params.key?(:expects) && ![*params[:expects]].include?(response.status)
-            raise(Excon::Errors.status_error(params, response))
+            e = Excon::Errors::NotFound.new("Expected([200]) <=> Actual(404 Not Found)", "404", response)
+            raise ServiceError.slurp(e)
+
           else response
           end
         end

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -1,5 +1,6 @@
 require File.expand_path("../ecloud/models/model", __FILE__)
 require File.expand_path("../ecloud/models/collection", __FILE__)
+require File.expand_path("../ecloud/errors", __FILE__)
 
 module Fog
   module Compute
@@ -266,97 +267,11 @@ module Fog
         end
       end
 
-      # Custom errors specific to our implementation
-      module Errors
-        # The parent class for all errors in the Fog::Compute::Ecloud module.
-        class Fog::Compute::Ecloud::ServiceError < Fog::Errors::Error
-          # @!attribute [r] response_data
-          #   @return [string] the response from the HTTP request
-
-          # @!attribute [r] status_code
-          #   @return [Integer] the HTTP status code returned
-          attr_reader :response_data, :status_code, :minor_error_code
-
-          # Make the HTTP status code pretty
-          #
-          # @return [String] the cleaned up status code
-          def to_s
-            status = status_code ? "HTTP #{status_code}" : "HTTP <Unknown>"
-            minor_code = minor_error_code ? minor_error_code : "Unknown"
-            "[#{status} - #{minor_code}] #{super}"
-          end
-
-          # Parse the response from the HTTP request to create a user friendly
-          #   message, including HTTP response code and error message (if any)
-          #
-          # @param [Object] error the error object from the rescue block
-          #
-          # @return [Object] the new error object
-          def self.slurp(error)
-            data = nil
-            message = nil
-            status_code = nil
-            minor_code = nil
-
-            if error.response
-              status_code = error.response.status
-              unless error.response.body.empty?
-                begin
-                  document = Fog::ToHashDocument.new
-                  parser = Nokogiri::XML::SAX::PushParser.new(document)
-                  parser << error.response.body
-                  parser.finish
-
-                  data = document.body
-
-                  message = extract_message(data)
-                  minor_code = extract_minor_code(data)
-
-                rescue => e
-                  Fog::Logger.warning("Received exception '#{e}' while decoding: #{error.response.body}")
-                  message = error.response.body
-                  data = error.response.body
-                end
-              end
-            end
-
-            new_error = super(error, message)
-            new_error.instance_variable_set(:@response_data, data)
-            new_error.instance_variable_set(:@status_code, status_code)
-            new_error.instance_variable_set(:@minor_error_code, minor_code)
-            new_error
-          end
-
-          # Parse the response body for an error message
-          #
-          # @param [Hash] data the decoded XML response
-          #
-          # @return [String] the error message, if found, otherwise the raw data
-          def self.extract_message(data)
-            if data.is_a?(Hash)
-              message = data[:message]
-            end
-            message || data.inspect
-          end
-
-          # Parse the response body for the minor error code
-          #
-          # @param [Hash] data the decoded XML response
-          #
-          # @return [String] the error minor error code, if found, otherwise nil
-          def self.extract_minor_code(data)
-            minor_code = nil
-            if data.is_a?(Hash)
-              minor_code = data[:minorErrorCode]
-            end
-            minor_code
-          end
-        end
-      end
-
       class Real
         include Shared
         include Errors
+
+        class Fog::Compute::Ecloud::ServiceError < Fog::Ecloud::Errors::ServiceError ; end
 
         class << self
           def basic_request(name, expects = [200], method = :get, headers = {}, body = "")
@@ -522,6 +437,8 @@ module Fog
       class Mock
         include Shared
         include Errors
+
+        class Fog::Compute::Ecloud::ServiceError < Fog::Ecloud::Errors::ServiceError ; end
 
         def self.data
           @data ||= Hash.new do |hash, key|

--- a/lib/fog/compute/ecloud/errors.rb
+++ b/lib/fog/compute/ecloud/errors.rb
@@ -1,0 +1,91 @@
+module Fog
+  module Ecloud
+    # Custom errors specific to our implementation
+    module Errors
+      # The parent class for all errors in the Fog::Compute::Ecloud module.
+      class ServiceError < Fog::Errors::Error
+        # @!attribute [r] response_data
+        #   @return [string] the response from the HTTP request
+
+        # @!attribute [r] status_code
+        #   @return [Integer] the HTTP status code returned
+        attr_reader :response_data, :status_code, :minor_error_code
+
+        # Make the HTTP status code pretty
+        #
+        # @return [String] the cleaned up status code
+        def to_s
+          status = status_code ? "HTTP #{status_code}" : "HTTP <Unknown>"
+          minor_code = minor_error_code ? minor_error_code : "Unknown"
+          "[#{status} - #{minor_code}] #{super}"
+        end
+
+        # Parse the response from the HTTP request to create a user friendly
+        #   message, including HTTP response code and error message (if any)
+        #
+        # @param [Object] error the error object from the rescue block
+        #
+        # @return [Object] the new error object
+        def self.slurp(error)
+          data = nil
+          message = nil
+          status_code = nil
+          minor_code = nil
+
+          if error.response
+            status_code = error.response.status
+            unless error.response.body.empty?
+              begin
+                document = Fog::ToHashDocument.new
+                parser = Nokogiri::XML::SAX::PushParser.new(document)
+                parser << error.response.body
+                parser.finish
+
+                data = document.body
+
+                message = extract_message(data)
+                minor_code = extract_minor_code(data)
+
+              rescue => e
+                Fog::Logger.warning("Received exception '#{e}' while decoding: #{error.response.body}")
+                message = error.response.body
+                data = error.response.body
+              end
+            end
+          end
+
+          new_error = super(error, message)
+          new_error.instance_variable_set(:@response_data, data)
+          new_error.instance_variable_set(:@status_code, status_code)
+          new_error.instance_variable_set(:@minor_error_code, minor_code)
+          new_error
+        end
+
+        # Parse the response body for an error message
+        #
+        # @param [Hash] data the decoded XML response
+        #
+        # @return [String] the error message, if found, otherwise the raw data
+        def self.extract_message(data)
+          if data.is_a?(Hash)
+            message = data[:message]
+          end
+          message || data.inspect
+        end
+
+        # Parse the response body for the minor error code
+        #
+        # @param [Hash] data the decoded XML response
+        #
+        # @return [String] the error minor error code, if found, otherwise nil
+        def self.extract_minor_code(data)
+          minor_code = nil
+          if data.is_a?(Hash)
+            minor_code = data[:minorErrorCode]
+          end
+          minor_code
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/ecloud/models/admin_organizations.rb
+++ b/lib/fog/compute/ecloud/models/admin_organizations.rb
@@ -12,7 +12,8 @@ module Fog
           if data = service.get_admin_organization(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/api_keys.rb
+++ b/lib/fog/compute/ecloud/models/api_keys.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_api_key(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/associations.rb
+++ b/lib/fog/compute/ecloud/models/associations.rb
@@ -25,7 +25,8 @@ module Fog
           if data = service.get_association(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/authentication_levels.rb
+++ b/lib/fog/compute/ecloud/models/authentication_levels.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_authentication_level(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/backup_internet_services.rb
+++ b/lib/fog/compute/ecloud/models/backup_internet_services.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_backup_internet_service(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/catalog.rb
+++ b/lib/fog/compute/ecloud/models/catalog.rb
@@ -30,7 +30,8 @@ module Fog
           if data = service.get_catalog_item(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/catalog.rb
+++ b/lib/fog/compute/ecloud/models/catalog.rb
@@ -9,7 +9,7 @@ module Fog
         model Fog::Compute::Ecloud::CatalogItem
 
         def all
-          data = service.get_catalog(href).body#[:Locations][:Location][:Catalog][:CatalogEntry]
+          data = service.get_catalog(href).body # [:Locations][:Location][:Catalog][:CatalogEntry]
           if data[:Locations][:Location].is_a?(Hash)
             data = [] if data[:Locations][:Location][:Catalog].is_a?(String) && data[:Locations][:Location][:Catalog].empty?
             load(data)

--- a/lib/fog/compute/ecloud/models/catalog_configurations.rb
+++ b/lib/fog/compute/ecloud/models/catalog_configurations.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_catalog_configuration(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/compute_pools.rb
+++ b/lib/fog/compute/ecloud/models/compute_pools.rb
@@ -20,7 +20,8 @@ module Fog
           if data = service.get_compute_pool(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/cpu_usage_detail_summary.rb
+++ b/lib/fog/compute/ecloud/models/cpu_usage_detail_summary.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_cpu_usage_detail(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/detached_disks.rb
+++ b/lib/fog/compute/ecloud/models/detached_disks.rb
@@ -10,7 +10,7 @@ module Fog
 
         def all
           data = service.get_detached_disks(href).body[:DetachedDisk]
-					data = [] if data.nil?
+          data = [] if data.nil?
           load(data)
         end
 

--- a/lib/fog/compute/ecloud/models/detached_disks.rb
+++ b/lib/fog/compute/ecloud/models/detached_disks.rb
@@ -17,7 +17,8 @@ module Fog
         def get(uri)
           data = service.get_detached_disk(uri).body
           new(data)
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/environments.rb
+++ b/lib/fog/compute/ecloud/models/environments.rb
@@ -38,7 +38,8 @@ module Fog
           if data = service.get_environment(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/firewall_acls.rb
+++ b/lib/fog/compute/ecloud/models/firewall_acls.rb
@@ -18,7 +18,8 @@ module Fog
           if data = service.get_firewall_acl(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/groups.rb
+++ b/lib/fog/compute/ecloud/models/groups.rb
@@ -29,7 +29,8 @@ module Fog
           else
             new(data)
           end
-        rescue Excon::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/guest_processes.rb
+++ b/lib/fog/compute/ecloud/models/guest_processes.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_guest_process(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/hardware_configurations.rb
+++ b/lib/fog/compute/ecloud/models/hardware_configurations.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_hardware_configuration(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/internet_services.rb
+++ b/lib/fog/compute/ecloud/models/internet_services.rb
@@ -20,7 +20,8 @@ module Fog
         def get(uri)
           data = service.get_internet_service(uri).body
           new(data)
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/internet_services.rb
+++ b/lib/fog/compute/ecloud/models/internet_services.rb
@@ -27,13 +27,13 @@ module Fog
 
         def create(options)
           options[:uri] = "#{service.base_path}/internetServices/publicIps/#{public_ip_id}/action/createInternetService"
-          options[:protocol]           ||= "TCP"
-          options[:enabled]            ||= true
-          options[:description]        ||= ""
-          options[:persistence]        ||= {}
+          options[:protocol] ||= "TCP"
+          options[:enabled] ||= true
+          options[:description] ||= ""
+          options[:persistence] ||= {}
           options[:persistence][:type] ||= "None"
           data = service.internet_service_create(options).body
-          object = new(data)
+          new(data)
         end
 
         def public_ip_id

--- a/lib/fog/compute/ecloud/models/ip_addresses.rb
+++ b/lib/fog/compute/ecloud/models/ip_addresses.rb
@@ -23,7 +23,8 @@ module Fog
           if data = service.get_ip_address(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/layouts.rb
+++ b/lib/fog/compute/ecloud/models/layouts.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_layout(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/locations.rb
+++ b/lib/fog/compute/ecloud/models/locations.rb
@@ -19,7 +19,8 @@ module Fog
           if data = service.get_location(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/login_banners.rb
+++ b/lib/fog/compute/ecloud/models/login_banners.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_login_banner(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/memory_usage_detail_summary.rb
+++ b/lib/fog/compute/ecloud/models/memory_usage_detail_summary.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_memory_usage_detail(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/monitors.rb
+++ b/lib/fog/compute/ecloud/models/monitors.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_monitor(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/networks.rb
+++ b/lib/fog/compute/ecloud/models/networks.rb
@@ -9,7 +9,7 @@ module Fog
         model Fog::Compute::Ecloud::Network
 
         def all
-          body = service.get_networks(self.href).body
+          body = service.get_networks(href).body
           body = body[:Networks] ? body[:Networks][:Network] : body[:Network]
           data = case body
                  when NilClass then []

--- a/lib/fog/compute/ecloud/models/networks.rb
+++ b/lib/fog/compute/ecloud/models/networks.rb
@@ -23,7 +23,8 @@ module Fog
           if data = service.get_network(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/nodes.rb
+++ b/lib/fog/compute/ecloud/models/nodes.rb
@@ -31,7 +31,7 @@ module Fog
           options[:enabled] ||= true
           options[:description] ||= ""
           data = service.node_service_create(options).body
-          object = new(data)
+          new(data)
         end
 
         def internet_service_id

--- a/lib/fog/compute/ecloud/models/nodes.rb
+++ b/lib/fog/compute/ecloud/models/nodes.rb
@@ -20,7 +20,8 @@ module Fog
         def get(uri)
           data = service.get_node(uri).body
           new(data)
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/operating_system_families.rb
+++ b/lib/fog/compute/ecloud/models/operating_system_families.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_operating_system(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/operating_systems.rb
+++ b/lib/fog/compute/ecloud/models/operating_systems.rb
@@ -16,7 +16,8 @@ module Fog
           if data = service.get_operating_system(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/organizations.rb
+++ b/lib/fog/compute/ecloud/models/organizations.rb
@@ -19,7 +19,8 @@ module Fog
           if data = service.get_organization(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/password_complexity_rules.rb
+++ b/lib/fog/compute/ecloud/models/password_complexity_rules.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_password_complexity_rule(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/physical_devices.rb
+++ b/lib/fog/compute/ecloud/models/physical_devices.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_physical_device(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/public_ips.rb
+++ b/lib/fog/compute/ecloud/models/public_ips.rb
@@ -17,7 +17,8 @@ module Fog
         def get(uri)
           data = service.get_public_ip(uri).body
           new(data)
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/public_ips.rb
+++ b/lib/fog/compute/ecloud/models/public_ips.rb
@@ -24,7 +24,7 @@ module Fog
 
         def activate
           data = service.public_ip_activate(href + "/action/activatePublicIp").body
-          ip = Fog::Compute::Ecloud::PublicIps.new(:service => service, :href => data[:href])[0]
+          Fog::Compute::Ecloud::PublicIps.new(:service => service, :href => data[:href])[0]
         end
       end
     end

--- a/lib/fog/compute/ecloud/models/rnats.rb
+++ b/lib/fog/compute/ecloud/models/rnats.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_rnat(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/roles.rb
+++ b/lib/fog/compute/ecloud/models/roles.rb
@@ -27,7 +27,8 @@ module Fog
           if data = service.get_role(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/rows.rb
+++ b/lib/fog/compute/ecloud/models/rows.rb
@@ -20,7 +20,8 @@ module Fog
           else
             new(data)
           end
-        rescue Excon::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/server.rb
+++ b/lib/fog/compute/ecloud/models/server.rb
@@ -31,7 +31,7 @@ module Fog
         end
 
         def flavor_id
-          {:ram => hardware_configuration.memory.to_i, :cpus => hardware_configuration.processor_count}
+          { :ram => hardware_configuration.memory.to_i, :cpus => hardware_configuration.processor_count }
         end
 
         def storage
@@ -39,7 +39,7 @@ module Fog
         end
 
         def tasks
-          @tasks ||= self.service.tasks(:href => "#{service.base_path}/tasks/virtualMachines/#{id}")
+          @tasks ||= service.tasks(:href => "#{service.base_path}/tasks/virtualMachines/#{id}")
         end
 
         def processes
@@ -47,11 +47,11 @@ module Fog
         end
 
         def hardware_configuration=(hardware_configuration)
-          @hardware_configuration = self.service.hardware_configurations.new(hardware_configuration)
+          @hardware_configuration = service.hardware_configurations.new(hardware_configuration)
         end
 
         def hardware_configuration
-          @hardware_configuration ||= self.service.hardware_configurations.new(:href => "#{service.base_path}/virtualMachines/#{id}/hardwareConfiguration")
+          @hardware_configuration ||= service.hardware_configurations.new(:href => "#{service.base_path}/virtualMachines/#{id}/hardwareConfiguration")
           @hardware_configuration.reload
         end
 
@@ -60,36 +60,36 @@ module Fog
         end
 
         def ips
-          @ips = self.service.virtual_machine_assigned_ips(:virtual_machine_id => self.id)
+          @ips = service.virtual_machine_assigned_ips(:virtual_machine_id => id)
         end
 
         def networks
-          @networks ||= self.service.networks(:href => "#{service.base_path}/virtualMachines/#{id}/assignedIps")
+          @networks ||= service.networks(:href => "#{service.base_path}/virtualMachines/#{id}/assignedIps")
         end
 
         def power_on
-          power_operation( :power_on => :powerOn )
+          power_operation(:power_on => :powerOn)
         end
 
         def power_off
-          power_operation( :power_off => :powerOff )
+          power_operation(:power_off => :powerOff)
         end
 
         def shutdown
-          power_operation( :power_shutdown => :shutdown )
+          power_operation(:power_shutdown => :shutdown)
         end
 
         def power_reset
-          power_operation( :power_reset => :reboot )
+          power_operation(:power_reset => :reboot)
         end
 
         def delete
           data = service.virtual_machine_delete(href).body
-          self.service.tasks.new(data)
+          service.tasks.new(data)
         end
 
         def copy(options = {})
-          options = {:type => :copy}.merge(options)
+          options = { :type => :copy }.merge(options)
           options[:source] ||= href
           if options[:type] == :copy
             options[:cpus] ||= 1
@@ -103,7 +103,7 @@ module Fog
               options[:network_uri] = options[:network_uri].is_a?(String) ? [options[:network_uri]] : options[:network_uri]
               options[:network_uri].each do |uri|
                 index = options[:network_uri].index(uri)
-                ip = Fog::Compute::Ecloud::IpAddresses.new(:service => service, :href => uri).find { |i| i.host == nil }.name
+                ip = Fog::Compute::Ecloud::IpAddresses.new(:service => service, :href => uri).detect { |i| i.host == nil }.name
                 options[:ips] ||= []
                 options[:ips][index] = ip
               end
@@ -142,7 +142,7 @@ module Fog
         def edit(options = {})
           data = service.virtual_machine_edit(href, options).body
           if data[:type] == "application/vnd.tmrk.cloud.task"
-            task = Fog::Compute::Ecloud::Tasks.new(:service => service, :href => data[:href])[0]
+            Fog::Compute::Ecloud::Tasks.new(:service => service, :href => data[:href])[0]
           end
         end
 
@@ -150,7 +150,7 @@ module Fog
           options[:host_ip_href] ||= ips.first.href
           options[:uri] = "#{service.base_path}/rnats/environments/#{environment_id}/action/createAssociation"
           data = service.rnat_associations_create_device(options).body
-          rnat = Fog::Compute::Ecloud::Associations.new(:service => service, :href => data[:href])[0]
+          Fog::Compute::Ecloud::Associations.new(:service => service, :href => data[:href])[0]
         end
 
         def disks
@@ -161,18 +161,18 @@ module Fog
 
         def add_disk(size)
           index = disks.map { |d| d[:Index].to_i }.sort[-1] + 1
-          vm_disks = disks << {:Index => index.to_s, :Size=>{:Unit => "GB", :Value => size.to_s}, :Name => "Hard Disk #{index + 1}"}
+          vm_disks = disks << { :Index => index.to_s, :Size => { :Unit => "GB", :Value => size.to_s }, :Name => "Hard Disk #{index + 1}" }
           data = service.virtual_machine_edit_hardware_configuration(href + "/hardwareConfiguration", _configuration_data(:disks => vm_disks)).body
-          task = self.service.tasks.new(data)
+          service.tasks.new(data)
         end
 
         def detach_disk(index)
           options               = {}
-          options[:disk]        = disks.find { |disk_hash| disk_hash[:Index] == index.to_s }
-          options[:name]        = self.name
-          options[:description] = self.description
+          options[:disk]        = disks.detect { |disk_hash| disk_hash[:Index] == index.to_s }
+          options[:name]        = name
+          options[:description] = description
           data                  = service.virtual_machine_detach_disk(href + "/hardwareconfiguration/disks/actions/detach", options).body
-          detached_disk         = self.service.detached_disks.new(data)
+          service.detached_disks.new(data)
         end
 
         def attach_disk(detached_disk)
@@ -180,13 +180,13 @@ module Fog
           options[:name] = detached_disk.name
           options[:href] = detached_disk.href
           data           = service.virtual_machine_attach_disk(href + "/hardwareconfiguration/disks/actions/attach", options).body
-          task           = self.service.tasks.new(data)
+          service.tasks.new(data)
         end
 
         def delete_disk(index)
           vm_disks = disks.delete_if { |h| h[:Index] == index.to_s }
           data     = service.virtual_machine_edit_hardware_configuration(href + "/hardwareconfiguration", _configuration_data(:disks => vm_disks)).body
-          task     = self.service.tasks.new(data)
+          service.tasks.new(data)
         end
 
         def nics
@@ -197,9 +197,9 @@ module Fog
 
         def add_nic(network)
           unit_number = nics.map { |n| n[:UnitNumber].to_i }.sort[-1] + 1
-          vm_nics = nics << {:UnitNumber => unit_number, :Network => {:href => network.href, :name => network.name, :type => "application/vnd.tmrk.cloud.network"}}
+          vm_nics = nics << { :UnitNumber => unit_number, :Network => { :href => network.href, :name => network.name, :type => "application/vnd.tmrk.cloud.network" } }
           data = service.virtual_machine_edit_hardware_configuration(href + "/hardwareConfiguration", _configuration_data(:nics => vm_nics)).body
-          task = self.service.tasks.new(:href => data[:href])[0]
+          service.tasks.new(:href => data[:href])[0]
         end
 
         def add_ip(options)
@@ -211,7 +211,7 @@ module Fog
           slice_networks = if slice_ips.empty?
                              []
                            else
-                             ips.map { |ip| { :href => ip.network.href, :name => ip.network.name.split(" ")[0], :type => ip.network.type} }.push(:href => options[:href], :name => options[:network_name], :type => "application/vnd.tmrk.cloud.network").uniq
+                             ips.map { |ip| { :href => ip.network.href, :name => ip.network.name.split(" ")[0], :type => ip.network.type } }.push(:href => options[:href], :name => options[:network_name], :type => "application/vnd.tmrk.cloud.network").uniq
                            end
           slice_ips = slice_ips.map { |i| { :name => i.address.name, :network_name => i.network.name } }.push(:name => options[:ip], :network_name => options[:network_name]).uniq
           slice_ips.each do |ip|
@@ -223,7 +223,7 @@ module Fog
             end
           end
           data = service.virtual_machine_edit_assigned_ips(href + "/assignedIps", slice_networks).body
-          task = self.service.tasks.new(data)
+          service.tasks.new(data)
         end
 
         def delete_ip(options)
@@ -243,7 +243,7 @@ module Fog
                                }
                              end # .delete_if { |ip| ip[:href] == options[:href] && ip[:name] == options[:network_name] }
                            end
-          slice_ips.map! { |i| {:name => i.address.name, :network_name => i.network.name } }.delete_if { |ip| ip[:name] == options[:ip] }
+          slice_ips.map! { |i| { :name => i.address.name, :network_name => i.network.name } }.delete_if { |ip| ip[:name] == options[:ip] }
           slice_ips.each do |ip|
             slice_networks.each do |network|
               if network[:name] == ip[:network_name]
@@ -252,7 +252,7 @@ module Fog
             end
           end
           data = service.virtual_machine_edit_assigned_ips(href + "/assignedips", slice_networks).body
-          task = self.service.tasks.new(data)
+          service.tasks.new(data)
         end
 
         def upload_file(options)
@@ -261,16 +261,15 @@ module Fog
         end
 
         def storage_size
-          vm_disks = disks
-          disks.map! { |d| d[:Size][:Value].to_i }.reduce(0){|sum,item| sum + item} * 1024 * 1024
+          disks.map! { |d| d[:Size][:Value].to_i }.inject(0) { |sum, item| sum + item } * 1024 * 1024
         end
 
         def ready?
           load_unless_loaded!
-          unless status =~ /NotDeployed|Orphaned|TaskInProgress|CopyInProgress/
-            true
-          else
+          if status =~ /NotDeployed|Orphaned|TaskInProgress|CopyInProgress/
             false
+          else
+            true
           end
         end
 
@@ -283,16 +282,16 @@ module Fog
         end
 
         def compute_pool_id
-          other_links.find { |l| l[:type] == "application/vnd.tmrk.cloud.computePool" }[:href].scan(/\d+/)[0]
+          other_links.detect { |l| l[:type] == "application/vnd.tmrk.cloud.computePool" }[:href].scan(/\d+/)[0]
         end
 
         def compute_pool
           reload if other_links.nil?
-          @compute_pool = self.service.compute_pools.new(:href => other_links.find { |l| l[:type] == "application/vnd.tmrk.cloud.computePool" }[:href])
+          @compute_pool = service.compute_pools.new(:href => other_links.detect { |l| l[:type] == "application/vnd.tmrk.cloud.computePool" }[:href])
         end
 
         def environment_id
-          other_links.find { |l| l[:type] == "application/vnd.tmrk.cloud.environment" }[:href].scan(/\d+/)[0]
+          other_links.detect { |l| l[:type] == "application/vnd.tmrk.cloud.environment" }[:href].scan(/\d+/)[0]
         end
 
         def id
@@ -302,15 +301,15 @@ module Fog
         private
 
         def _configuration_data(options = {})
-          {:cpus => (options[:cpus] || hardware_configuration.processor_count), :memory => (options[:memory] || hardware_configuration.memory), :disks => (options[:disks] || disks), :nics => (options[:nics] || nics)}
+          { :cpus => (options[:cpus] || hardware_configuration.processor_count), :memory => (options[:memory] || hardware_configuration.memory), :disks => (options[:disks] || disks), :nics => (options[:nics] || nics) }
         end
 
         def power_operation(op)
           requires :href
           begin
-            service.send(op.keys.first, href + "/action/#{op.values.first}" )
+            service.send(op.keys.first, href + "/action/#{op.values.first}")
           rescue ServiceError => e
-            #Frankly we shouldn't get here ...
+            # Frankly we shouldn't get here ...
             raise e unless e.to_s =~ /because it is already powered o(n|ff)/
           end
           true

--- a/lib/fog/compute/ecloud/models/server.rb
+++ b/lib/fog/compute/ecloud/models/server.rb
@@ -309,7 +309,7 @@ module Fog
           requires :href
           begin
             service.send(op.keys.first, href + "/action/#{op.values.first}" )
-          rescue Excon::Errors::Conflict => e
+          rescue ServiceError => e
             #Frankly we shouldn't get here ...
             raise e unless e.to_s =~ /because it is already powered o(n|ff)/
           end

--- a/lib/fog/compute/ecloud/models/server_configuration_options.rb
+++ b/lib/fog/compute/ecloud/models/server_configuration_options.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_server_configuration_option(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/servers.rb
+++ b/lib/fog/compute/ecloud/models/servers.rb
@@ -32,11 +32,11 @@ module Fog
           new(data)
         end
 
-        def create( template_uri, options )
-          options[:cpus]        ||= 1
-          options[:memory]      ||= 512
+        def create(template_uri, options)
+          options[:cpus] ||= 1
+          options[:memory] ||= 512
           options[:description] ||= ""
-          options[:tags]        ||= []
+          options[:tags] ||= []
 
           if template_uri =~ /\/templates\/\d+/
             options[:uri] = href + "/action/createVirtualMachine"
@@ -47,17 +47,17 @@ module Fog
             else
               [*options[:network_uri]].each do |uri|
                 index = options[:network_uri].index(uri)
-                ip = self.service.ip_addresses(:href => uri).find { |i| i.host == nil && i.detected_on.nil? }.name
+                ip = service.ip_addresses(:href => uri).detect { |i| i.host == nil && i.detected_on.nil? }.name
                 options[:ips] ||= []
                 options[:ips][index] = ip
               end
             end
-            data = service.virtual_machine_create_from_template( template_uri, options ).body
+            data = service.virtual_machine_create_from_template(template_uri, options).body
           else
             options[:uri] = href + "/action/importVirtualMachine"
-            data = service.virtual_machine_import( template_uri, options ).body
+            data = service.virtual_machine_import(template_uri, options).body
           end
-          object = self.service.servers.new(data)
+          object = service.servers.new(data)
           object
         end
       end

--- a/lib/fog/compute/ecloud/models/servers.rb
+++ b/lib/fog/compute/ecloud/models/servers.rb
@@ -23,7 +23,8 @@ module Fog
         def get(uri)
           data = service.get_server(uri).body
           new(data)
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_ssh_key(uri).body
             new(data)
           end
-        rescue Excon::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
 

--- a/lib/fog/compute/ecloud/models/ssh_keys.rb
+++ b/lib/fog/compute/ecloud/models/ssh_keys.rb
@@ -9,7 +9,7 @@ module Fog
         model Fog::Compute::Ecloud::SshKey
 
         def all
-          data = service.get_ssh_keys(href).body[:SshKey]
+          data = service.get_ssh_keys(href).body[:SshKey] || []
           load(data)
         end
 

--- a/lib/fog/compute/ecloud/models/storage_usage_detail_summary.rb
+++ b/lib/fog/compute/ecloud/models/storage_usage_detail_summary.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_storage_usage_detail(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/support_tickets.rb
+++ b/lib/fog/compute/ecloud/models/support_tickets.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_support_ticket(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/tags.rb
+++ b/lib/fog/compute/ecloud/models/tags.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_tag(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/tasks.rb
+++ b/lib/fog/compute/ecloud/models/tasks.rb
@@ -20,7 +20,8 @@ module Fog
           if data = service.get_task(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/templates.rb
+++ b/lib/fog/compute/ecloud/models/templates.rb
@@ -32,7 +32,8 @@ module Fog
           if data = service.get_template(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/trusted_network_groups.rb
+++ b/lib/fog/compute/ecloud/models/trusted_network_groups.rb
@@ -18,7 +18,8 @@ module Fog
           if data = service.get_trusted_network_group(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/users.rb
+++ b/lib/fog/compute/ecloud/models/users.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_user(uri)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/models/virtual_machine_assigned_ips.rb
+++ b/lib/fog/compute/ecloud/models/virtual_machine_assigned_ips.rb
@@ -9,12 +9,12 @@ module Fog
         model Fog::Compute::Ecloud::VirtualMachineAssignedIp
 
         def all
-          data = service.get_virtual_machine_assigned_ips(self.identity).body
+          data = service.get_virtual_machine_assigned_ips(identity).body
           load(data)
         end
 
-        def get(uri)
-          if data = service.get_virtual_machine_assigned_ip(self.identity)
+        def get
+          if data = service.get_virtual_machine_assigned_ip(identity)
             new(data.body)
           end
         rescue ServiceError => e

--- a/lib/fog/compute/ecloud/models/virtual_machine_assigned_ips.rb
+++ b/lib/fog/compute/ecloud/models/virtual_machine_assigned_ips.rb
@@ -17,7 +17,8 @@ module Fog
           if data = service.get_virtual_machine_assigned_ip(self.identity)
             new(data.body)
           end
-        rescue Fog::Errors::NotFound
+        rescue ServiceError => e
+          raise e unless e.status_code == 404
           nil
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_admin_organization.rb
+++ b/lib/fog/compute/ecloud/requests/get_admin_organization.rb
@@ -14,7 +14,9 @@ module Fog
             body = Fog::Ecloud.slice(admin_organization, :id, :organization_id)
 
             response(:body => body)
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_admin_organization.rb
+++ b/lib/fog/compute/ecloud/requests/get_admin_organization.rb
@@ -8,7 +8,7 @@ module Fog
       class Mock
         def get_admin_organization(uri)
           organization_id = id_from_uri(uri)
-          admin_organization    = self.data[:admin_organizations][organization_id]
+          admin_organization = data[:admin_organizations][organization_id]
 
           if admin_organization
             body = Fog::Ecloud.slice(admin_organization, :id, :organization_id)

--- a/lib/fog/compute/ecloud/requests/get_compute_pool.rb
+++ b/lib/fog/compute/ecloud/requests/get_compute_pool.rb
@@ -12,7 +12,9 @@ module Fog
 
           if compute_pool
             response(:body => Fog::Ecloud.slice(compute_pool, :id, :environment))
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_compute_pool.rb
+++ b/lib/fog/compute/ecloud/requests/get_compute_pool.rb
@@ -8,7 +8,7 @@ module Fog
       class Mock
         def get_compute_pool(uri)
           compute_pool_id = id_from_uri(uri)
-          compute_pool = self.data[:compute_pools][compute_pool_id]
+          compute_pool = data[:compute_pools][compute_pool_id]
 
           if compute_pool
             response(:body => Fog::Ecloud.slice(compute_pool, :id, :environment))

--- a/lib/fog/compute/ecloud/requests/get_environment.rb
+++ b/lib/fog/compute/ecloud/requests/get_environment.rb
@@ -8,12 +8,12 @@ module Fog
       class Mock
         def get_environment(uri)
           environment_id = id_from_uri(uri)
-          organizations = self.data[:organizations].values
+          organizations = data[:organizations].values
           environment = nil
           catch(:found) do
             organizations.each do |organization|
               organization[:Locations][:Location].each do |location|
-                environment = location[:Environments][:Environment].find{|e| e[:id] == environment_id}
+                environment = location[:Environments][:Environment].detect { |e| e[:id] == environment_id }
                 throw :found if environment
               end
             end

--- a/lib/fog/compute/ecloud/requests/get_environment.rb
+++ b/lib/fog/compute/ecloud/requests/get_environment.rb
@@ -22,7 +22,9 @@ module Fog
             body = environment.dup
             body.delete(:id)
             response(:body => body)
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_ip_address.rb
+++ b/lib/fog/compute/ecloud/requests/get_ip_address.rb
@@ -11,7 +11,9 @@ module Fog
           ip_address = self.data[:networks][network_id.to_i][:IpAddresses][:IpAddress].find{|ip| ip[:name] == ip_address_id }.dup
           if ip_address
             response(:body => ip_address)
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_ip_address.rb
+++ b/lib/fog/compute/ecloud/requests/get_ip_address.rb
@@ -5,10 +5,10 @@ module Fog
         basic_request :get_ip_address
       end
 
-			class Mock
+      class Mock
         def get_ip_address(uri)
           network_id, ip_address_id = uri.match(/\/networks\/(\d+)\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/).captures
-          ip_address = self.data[:networks][network_id.to_i][:IpAddresses][:IpAddress].find{|ip| ip[:name] == ip_address_id }.dup
+          ip_address = data[:networks][network_id.to_i][:IpAddresses][:IpAddress].detect { |ip| ip[:name] == ip_address_id }.dup
           if ip_address
             response(:body => ip_address)
           else

--- a/lib/fog/compute/ecloud/requests/get_network.rb
+++ b/lib/fog/compute/ecloud/requests/get_network.rb
@@ -12,7 +12,9 @@ module Fog
 
           if network
             response(:body => Fog::Ecloud.slice(network, :id, :environment_id))
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_network.rb
+++ b/lib/fog/compute/ecloud/requests/get_network.rb
@@ -8,7 +8,7 @@ module Fog
       class Mock
         def get_network(uri)
           network_id = id_from_uri(uri)
-          network    = self.data[:networks][network_id].dup
+          network = data[:networks][network_id].dup
 
           if network
             response(:body => Fog::Ecloud.slice(network, :id, :environment_id))

--- a/lib/fog/compute/ecloud/requests/get_operating_system.rb
+++ b/lib/fog/compute/ecloud/requests/get_operating_system.rb
@@ -10,8 +10,8 @@ module Fog
           os_name, compute_pool_id = uri.match(/operatingsystems\/(.*)\/computepools\/(\d+)$/).captures
           compute_pool_id          = compute_pool_id.to_i
 
-          operating_systems = self.data[:operating_systems].values.select{|os| os[:compute_pool_id] == compute_pool_id}
-          operating_system = operating_systems.find{|os| os[:short_name] == os_name}
+          operating_systems = data[:operating_systems].values.select { |os| os[:compute_pool_id] == compute_pool_id }
+          operating_system = operating_systems.detect { |os| os[:short_name] == os_name }
 
           if operating_system
             response(:body => Fog::Ecloud.slice(operating_system, :id, :compute_pool_id, :short_name))

--- a/lib/fog/compute/ecloud/requests/get_operating_system.rb
+++ b/lib/fog/compute/ecloud/requests/get_operating_system.rb
@@ -15,7 +15,9 @@ module Fog
 
           if operating_system
             response(:body => Fog::Ecloud.slice(operating_system, :id, :compute_pool_id, :short_name))
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_ssh_key.rb
+++ b/lib/fog/compute/ecloud/requests/get_ssh_key.rb
@@ -12,7 +12,9 @@ module Fog
 
           if ssh_key
             response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization))
-          else response(:expects => 200, :status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/get_template.rb
+++ b/lib/fog/compute/ecloud/requests/get_template.rb
@@ -7,8 +7,8 @@ module Fog
 
       class Mock
         def get_template(uri)
-          template_id, compute_pool_id = uri.match(/(\d+).*\/(\d+)$/).captures
-          template    = self.data[:templates][template_id.to_i]
+          template_id, _compute_pool_id = uri.match(/(\d+).*\/(\d+)$/).captures
+          template = data[:templates][template_id.to_i]
 
           if template
             response(:body => Fog::Ecloud.slice(template, :id, :environment))

--- a/lib/fog/compute/ecloud/requests/get_template.rb
+++ b/lib/fog/compute/ecloud/requests/get_template.rb
@@ -12,7 +12,9 @@ module Fog
 
           if template
             response(:body => Fog::Ecloud.slice(template, :id, :environment))
-          else response(:status => 404) # ?
+          else
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
+++ b/lib/fog/compute/ecloud/requests/ssh_key_edit.rb
@@ -34,7 +34,8 @@ module Fog
             ssh_key = data[:ssh_keys][ssh_key_id]
             response(:body => Fog::Ecloud.slice(ssh_key, :id, :admin_organization)).body
           else
-            response(:expects => 200, :status => 404)
+            body = "<Error message=\"Resource Not Found\" majorErrorCode=\"404\" minorErrorCode=\"ResourceNotFound\" />"
+            response(:body => body, :expects => 200, :status => 404)
           end
         end
       end

--- a/lib/fog/ecloud/version.rb
+++ b/lib/fog/ecloud/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Ecloud
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -41,6 +41,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   tests("#delete").succeeds do
     the_key = @ssh_keys.get(@key_id)
     returns(false) { the_key.nil? }
+
     the_key.delete
     the_key = @ssh_keys.get(@key_id)
     returns(false) { !the_key.nil? }

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -1,4 +1,4 @@
-provider, config = :ecloud, compute_providers[:ecloud]
+provider = :ecloud
 
 Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   connection = Fog::Compute[provider]

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -15,7 +15,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
     ssh_key = @ssh_keys.first
 
     returns(false) { @ssh_keys.get(ssh_key.href).nil? }
-    returns(false) { @ssh_keys.get("/notfound" + ssh_key.href).nil? }
+    returns(true) { @ssh_keys.get(ssh_key.href + "314159").nil? }
   end
 
   tests("#create").succeeds do


### PR DESCRIPTION
This adds more robust exception handling for Excon requests by implementing a new error class that parses the response and outputs the relevant information. The exceptions are able to be rescued by consumers of the module.

I've also made the request exception handling consistent across the module. All requests now raise these exceptions, instead of some raising Fog::Errors::NotFound while others raised Excon::Errors::NotFound. This has smoothed out some edge cases and presents a much more consistent environment for module consumers to use.

I updated all mock request methods that could throw 404s to use this exception framework for more consistent testing.

I've also made, hopefully, the style and lint fixes that hound would object to. And my fork's travis builds all passed.