### PR TITLE
Livespec tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,11 +8,13 @@ Rake::TestTask.new do |t|
 end
 
 namespace :test do
-  mock = ENV['FOG_MOCK'] || 'true'
-  task :travis do
-    sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+  task :mock do
+    sh("export FOG_MOCK=true && bundle exec shindont -livespec")
+  end
+  task :livespec do
+    sh("export FOG_MOCK=false && bundle exec shindont +livespec")
   end
 end
 
 desc 'Default Task'
-task :default => [ :test, 'test:travis' ]
+task :default => [ :test, 'test:mock', 'test:livespec' ]

--- a/lib/fog/compute/ecloud.rb
+++ b/lib/fog/compute/ecloud.rb
@@ -397,7 +397,7 @@ module Fog
         end
 
         def cloud_api_signature(params)
-          verb = params[:method].upcase
+          verb = params[:method].to_s.upcase
           headers = params[:headers]
           path = params[:uri].path
           canonicalized_headers = canonicalize_headers(headers)

--- a/tests/compute/livespec/auth_tests.rb
+++ b/tests/compute/livespec/auth_tests.rb
@@ -1,0 +1,101 @@
+provider = :ecloud
+
+Shindo.tests("Fog::Compute[:#{provider}] | authentication", [provider.to_s, "livespec"]) do
+  raises(ArgumentError, "No authentication tokens supplied") do
+    _service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => nil,
+      :ecloud_password => nil,
+      :ecloud_access_key => nil,
+      :ecloud_private_key => nil
+    )
+  end
+
+  raises(ArgumentError, "Basic Authentication only username supplied") do
+    _service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => "somebody@somewhere.com",
+      :ecloud_password => nil,
+      :ecloud_access_key => nil,
+      :ecloud_private_key => nil
+    )
+  end
+
+  raises(ArgumentError, "Basic Authentication only password supplied") do
+    _service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => nil,
+      :ecloud_password => "T3rr3m@rk",
+      :ecloud_access_key => nil,
+      :ecloud_private_key => nil
+    )
+  end
+
+  returns(Fog::Compute::Ecloud::Organization, "Basic Authentication, valid account") do
+    service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => "somebody@somewhere.com",
+      :ecloud_password => "T3rr3m@rk",
+      :ecloud_access_key => nil,
+      :ecloud_private_key => nil
+    )
+    foo = service.organizations(:uri => "/organizations").first
+    foo.class
+  end
+
+  raises(Fog::Compute::Ecloud::ServiceError, "Basic Authentication, invalid account") do
+    service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => "notfound@terremark.com",
+      :ecloud_password => "something",
+      :ecloud_access_key => nil,
+      :ecloud_private_key => nil
+    )
+    foo = service.organizations(:uri => "/organizations").first
+    foo.class
+  end
+
+  raises(ArgumentError, "API Key Authentication only access key supplied") do
+    _service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => nil,
+      :ecloud_password => nil,
+      :ecloud_access_key => 33333333333333333333333333333333,
+      :ecloud_private_key => nil
+    )
+  end
+
+  raises(ArgumentError, "API Key Authentication only private key supplied") do
+    _service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => nil,
+      :ecloud_password => nil,
+      :ecloud_access_key => nil,
+      :ecloud_private_key => 3333333333333333333333333333333333333333333333333333333333333333
+    )
+  end
+
+  returns(Fog::Compute::Ecloud::Organization, "API Key Authentication, valid key") do
+    service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => nil,
+      :ecloud_password => nil,
+      :ecloud_access_key => 33333333333333333333333333333333,
+      :ecloud_private_key => 3333333333333333333333333333333333333333333333333333333333333333
+    )
+    foo = service.organizations(:uri => "/organizations").first
+    foo.class
+  end
+
+  raises(Fog::Compute::Ecloud::ServiceError, "API Key Authentication, invalid key") do
+    service = Fog::Compute::Ecloud.new(
+      :base_path => "/cloudapi/spec",
+      :ecloud_username => nil,
+      :ecloud_password => nil,
+      :ecloud_access_key => 99999999999999999999999999999999,
+      :ecloud_private_key => 9999999999999999999999999999999999999999999999999999999999999999,
+    )
+    foo = service.organizations(:uri => "/organizations").first
+    foo.class
+  end
+end

--- a/tests/compute/livespec/auth_tests.rb
+++ b/tests/compute/livespec/auth_tests.rb
@@ -93,7 +93,7 @@ Shindo.tests("Fog::Compute[:#{provider}] | authentication", [provider.to_s, "liv
       :ecloud_username => nil,
       :ecloud_password => nil,
       :ecloud_access_key => 99999999999999999999999999999999,
-      :ecloud_private_key => 9999999999999999999999999999999999999999999999999999999999999999,
+      :ecloud_private_key => 9999999999999999999999999999999999999999999999999999999999999999
     )
     foo = service.organizations(:uri => "/organizations").first
     foo.class

--- a/tests/compute/models/ssh_key_tests.rb
+++ b/tests/compute/models/ssh_key_tests.rb
@@ -8,42 +8,42 @@ Shindo.tests("Fog::Compute[:#{provider}] | ssh_keys", [provider.to_s]) do
   @ssh_keys = @admin_organization.ssh_keys
 
   tests("#all").succeeds do
-    returns(false) { @ssh_keys.empty? }
+    returns(false, "#all - get all ssh keys") { @ssh_keys.empty? }
   end
 
   tests("#get").succeeds do
     ssh_key = @ssh_keys.first
 
-    returns(false) { @ssh_keys.get(ssh_key.href).nil? }
-    returns(true) { @ssh_keys.get(ssh_key.href + "314159").nil? }
+    returns(false, "#get - fetch an existing ssh key") { @ssh_keys.get(ssh_key.href).nil? }
+    returns(true, "#get - fetch a nonexistant ssh key") { @ssh_keys.get(ssh_key.href + "314159").nil? }
   end
 
   tests("#create").succeeds do
     new_key = @ssh_keys.create(:Name => "testing")
     @key_id = new_key.id || nil
-    returns(false) { new_key.nil? }
-    raises(ArgumentError) { @ssh_keys.create }
+    returns(false, "#create - create the testing key") { new_key.nil? }
+    raises(ArgumentError, "#create - attempt create with no args") { @ssh_keys.create }
   end
 
   tests("#edit").succeeds do
     the_key = @ssh_keys.get(@key_id)
-    returns(false) { the_key.nil? }
+    returns(false, "#edit - fetch the key") { the_key.nil? }
 
     the_key.edit(:Name => "more testing")
     the_key.reload
-    returns(false) { the_key.name != "more testing" }
+    returns(false, "#edit - change name") { the_key.name != "more testing" }
 
     the_key.edit(:Default => true)
     the_key.reload
-    returns(true) { the_key.default }
+    returns(true, "#edit - change default") { the_key.default }
   end
 
   tests("#delete").succeeds do
     the_key = @ssh_keys.get(@key_id)
-    returns(false) { the_key.nil? }
+    returns(false, "#delete - fetch the key") { the_key.nil? }
 
     the_key.delete
     the_key = @ssh_keys.get(@key_id)
-    returns(false) { !the_key.nil? }
+    returns(false, "#delete - delete the key") { !the_key.nil? }
   end
 end


### PR DESCRIPTION
This adds the live spec tests I've written for authentication in to the testing system and renames the test:travis subtask to test:mock to more clearly identify what kind of tests are going on.

I've also added custom test names to the ssh tests to help with diagnosing which test is failing. Without them, the failures don't have meaningful labels so it's pretty hard to figure out what's actually failing.

Once I put the live spec tests in, it uncovered a bug in the cloud_api_signature method that only shows up when running under 1.8.7 and ree. That's been fixed as well.

All travis builds are passing on my fork, and rubocop is happy. Can we merge this and release a new gem?