### PR TITLE
Allow server to accept HardwareConfiguration object as well as Hash.

### DIFF
--- a/lib/fog/compute/ecloud/models/server.rb
+++ b/lib/fog/compute/ecloud/models/server.rb
@@ -47,6 +47,7 @@ module Fog
         end
 
         def hardware_configuration=(hardware_configuration)
+          hardware_configuration = hardware_configuration.attributes if hardware_configuration.respond_to? :attributes
           @hardware_configuration = service.hardware_configurations.new(hardware_configuration)
         end
 


### PR DESCRIPTION
When running with fog-core 2.x, the test suite fails as follows:

~~~
    Initialization parameters must be an attributes hash, got Fog::Compute::Ecloud::HardwareConfiguration     <Fog::Compute::Ecloud::HardwareConfiguration
      href=nil,
      processor_count=0,
      memory=nil,
      storage=nil,
      network_cards=nil
    > (ArgumentError)
      /usr/share/gems/gems/fog-core-2.1.2/lib/fog/core/collection.rb:86:in `new'
      /builddir/build/BUILD/fog-ecloud-0.3.0/usr/share/gems/gems/fog-ecloud-0.3.0/lib/fog/compute/ecloud/models/server.rb:50:in `hardware_configuration='
~~~

This is due to fog/fog-core/pull/218 and it seems reasonable to me to accept `Hash` as well as the `HardwareConfiguraiton` object on that place.

This fixes the test suite testing with fog-core 2.1.2 as well as 1.43.0. I am not a user of fog-ecloud, so I can't tell if it works in real scenarios.